### PR TITLE
WheelColliderの保護

### DIFF
--- a/Resources/Truck.prefab
+++ b/Resources/Truck.prefab
@@ -105,7 +105,7 @@ GameObject:
   - component: {fileID: 4963875892323372123}
   - component: {fileID: 6873528229979321338}
   - component: {fileID: 994926918500336387}
-  - component: {fileID: 1946556782}
+  - component: {fileID: 8585843017941314323}
   m_Layer: 0
   m_Name: Truck
   m_TagString: Untagged
@@ -216,7 +216,7 @@ MonoBehaviour:
     maxExtendRange: 2.5
     inverse: 0
   _controlSpeed: 0.05
---- !u!114 &1946556782
+--- !u!114 &8585843017941314323
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -225,7 +225,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 93083377421715034}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4f4542ad1a321004f94bad2cb219e42e, type: 3}
+  m_Script: {fileID: 11500000, guid: 7e833f55fcfea6b419590179cb5cfb2e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   _vehicle: {fileID: 994926918500336387}

--- a/Scenes/DumpTruck.unity
+++ b/Scenes/DumpTruck.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.4508031, g: 0.50073075, b: 0.5747243, a: 1}
+  m_IndirectSpecularColor: {r: 0.45080262, g: 0.5007299, b: 0.57472336, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -367,5 +367,14 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    - target: {fileID: 6873528229979321338, guid: 03867d45493f7e0479bf98219709eb7d, type: 3}
+      propertyPath: m_Size.x
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6873528229979321338, guid: 03867d45493f7e0479bf98219709eb7d, type: 3}
+      propertyPath: m_Center.z
+      value: 0.14
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 1946556782, guid: 03867d45493f7e0479bf98219709eb7d, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 03867d45493f7e0479bf98219709eb7d, type: 3}


### PR DESCRIPTION
<img width="448" alt="image" src="https://user-images.githubusercontent.com/26988372/147623621-3258afc1-a11c-4d30-92fa-ed18df060106.png">

上から落ちてきた土粒子がWheelColliderに衝突するとトラックが吹っ飛ぶので、BoxColliderの横幅を広げて保護するようにしました。